### PR TITLE
fix(theme): anchors were cut off visually

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,6 +113,10 @@ h1,h2,h3,h4,h5,h6 {
   color: #091C84;
 }
 
+.anchor {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 1rem) !important;
+}
+
 /* Remove topography background from pagination navigation */
 .pagination-nav {
   background: none;


### PR DESCRIPTION
Before (in this Docusaurus repo):

<img width="712" height="166" alt="Screenshot 2025-09-24 at 10 27 29 AM" src="https://github.com/user-attachments/assets/174049b5-7c1c-430f-9070-7642425c0abb" />

It's even worse on the production site. See https://github.com/helm/helm-www/issues/1785

After this fix:
<img width="720" height="164" alt="Screenshot 2025-09-24 at 10 37 49 AM" src="https://github.com/user-attachments/assets/3e5862d7-4f69-44d5-bda4-d9bf4e4d5443" />
